### PR TITLE
feat: parameterize rke2 readiness gate + optional air-gapped checksum

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -35,6 +35,8 @@ rke2_user_name: root
 rke2_task_can_possibly_fail: "{{ true if inventory_hostname in groups['additional_master_nodes'] else false }}"
 rke2_user_group: root
 rke2_server_service: rke2-server.service
+rke2_ready_retries: 40
+rke2_ready_delay: 30
 rke2_node_register_port: 9345
 k8s_api_port: 6443
 rke2_uninstall_script: /usr/local/bin/rke2-uninstall.sh
@@ -47,6 +49,10 @@ rke2_airgapped_image_url: "https://github.com/rancher/rke2/releases/download/v{{
 rke2_airgapped_installation: false
 rke2_airgapped_install_dir: "{{ rke_dir }}/agent/images/"
 rke2_airgapped_archive: rke2-images.linux-amd64.tar.zst
+# Optional checksum (e.g. "sha256:<hash>" or "sha256:<url>") for the air-gapped
+# image archive. Left undefined by default so the download behaviour is unchanged;
+# set it to make get_url verify the download and fail loudly on truncation.
+# rke2_airgapped_checksum: "sha256:..."
 add_crictl_alias: true
 rke2_bin_dir: "{{ rke_dir }}/bin/"
 rke2_containerd_sock: /run/k3s/containerd/containerd.sock

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -29,6 +29,7 @@
         url: "{{ rke2_airgapped_image_url }}"
         dest: "{{ rke2_airgapped_install_dir }}/{{ rke2_airgapped_archive }}"
         validate_certs: "{{ validate_certs }}"
+        checksum: "{{ rke2_airgapped_checksum | default(omit) }}"
 
   when: rke2_airgapped_installation|bool and not install_k3s and rke_state == "present"
 

--- a/tasks/start-rke2.yaml
+++ b/tasks/start-rke2.yaml
@@ -38,10 +38,21 @@
 
 - name: Test if rke2 server is successfully deployed
   ansible.builtin.shell: |
-    kubectl get nodes --kubeconfig {{ rke2_kubeconfig_name }}
+    set -o pipefail
+    # 1) apiserver must actually be serving before node status can be trusted;
+    #    a cold/not-yet-ready apiserver makes kubectl exit non-zero -> retry.
+    kubectl get --raw='/readyz' --kubeconfig {{ rke2_kubeconfig_name }} >/dev/null 2>&1 || exit 1
+    # 2) node list must be non-empty (empty stdout previously false-passed).
+    statuses=$(kubectl get nodes --no-headers --kubeconfig {{ rke2_kubeconfig_name }} 2>/dev/null | awk '{print $2}')
+    [ -n "${statuses}" ] || exit 1
+    # 3) no node may be NotReady and at least one node must report Ready.
+    echo "${statuses}" | grep -qw NotReady && exit 1
+    echo "${statuses}" | grep -qw Ready
   args:
     chdir: "{{ rke2_config_dir }}"
+    executable: /bin/bash
   register: cmd_result
-  retries: 20
-  delay: 30
-  until: ("NotReady" not in cmd_result.stdout)
+  retries: "{{ rke2_ready_retries }}"
+  delay: "{{ rke2_ready_delay }}"
+  until: cmd_result.rc == 0
+  changed_when: false


### PR DESCRIPTION
## What

Two backwards-compatible hardening changes to the rke2 deploy flow. All existing default values are preserved, so the other 26 releases' worth of consumers are unaffected.

### 1. Parameterize & harden the post-deploy readiness gate (`tasks/start-rke2.yaml`)
- `retries`/`delay` are now driven by **`rke2_ready_retries` (default 40)** and **`rke2_ready_delay` (default 30)** — raising the default timeout from 10 min to **20 min** so slow first-boots don't time out before the cluster is `Ready`.
- The gate can no longer **false-pass**. The old `until: ("NotReady" not in cmd_result.stdout)` was satisfied by *empty* stdout, which is exactly what `kubectl` emits when the apiserver isn't serving yet. The new gate:
  1. Confirms the apiserver is actually serving via `kubectl get --raw='/readyz'` (non-zero exit → retry),
  2. Requires a **non-empty** node list,
  3. Requires **no** `NotReady` nodes **and at least one** `Ready` node.
  
  Uses `until: cmd_result.rc == 0`, so a cold/not-yet-serving apiserver simply triggers a retry rather than a false success; only after `rke2_ready_retries` are exhausted does the task fail (default rc-based `failed_when`).

### 2. Optional checksum on the air-gapped image download (`tasks/main.yaml`)
- Added `checksum: "{{ rke2_airgapped_checksum | default(omit) }}"` to the `get_url`, so a truncated download fails loudly. The var is **unset by default** (documented in `defaults/main.yaml`), so current behaviour is unchanged.

## Testing
- ✅ `ansible-playbook --syntax-check` on the full molecule/rke2 play (incl. this role) — passes.
- ✅ Readiness-gate shell logic unit-tested against 7 cold-API / partial-readiness scenarios, confirming the previous empty-stdout false-pass is fixed and a cold apiserver retries instead of passing.
- ⚠️ **Molecule `converge` was NOT run** for this PR: the scenario uses `driver: default, managed: False` against the real host `10.31.103.33`, which was unreachable from the authoring environment. Please run `molecule test -s rke2` against the live host before merging. Note: a fast CI/host won't exercise the slow-boot path that motivated the timeout bump, so a green converge proves the happy path is intact but not the timeout fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)