### PR TITLE
feat: bump default k3s to v1.36.1+k3s1 and add overridable k3s air-gapped source

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,53 @@ ansible-playbook -i inv play.yaml -vv
 
 </details>
 
+<details><summary>EXAMPLE K3S AIRGAPPED PLAYBOOK</summary>
+
+```bash
+cat <<EOF > ./play.yaml
+- hosts: all
+  become: true
+
+  vars:
+    install_k3s: true
+    k3s_state: present #absent
+    k3s_k8s_version: 1.36.1
+    k3s_release_kind: k3s1
+    cluster_setup: singlenode
+    install_cillium: true
+
+    # --- air-gapped install -------------------------------------------------
+    # Pre-stage the images archive AND the k3s binary, then run the install
+    # script with INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream pull).
+    k3s_airgapped_installation: true
+
+    # Optional overrides (each defaults to the upstream release for the pinned
+    # version). Point them at a mirror / locally hosted artifact for a fully
+    # offline run:
+    # k3s_airgapped_image_url: "https://your-host/k3s-airgap-images-amd64.tar.zst"
+    # k3s_airgapped_archive: k3s-airgap-images-amd64.tar.zst
+    # k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
+    # k3s_airgapped_checksum: "sha256:..."          # optional, verifies the archive
+    # k3s_airgapped_binary_url: "https://your-host/k3s"
+    # k3s_airgapped_binary_dest: /usr/local/bin/k3s
+    # k3s_airgapped_binary_checksum: "sha256:..."   # optional, verifies the binary
+    # k3s_installscript_url: "https://your-host/k3s-install.sh"  # for zero egress
+
+    # SELinux toggles (default false). On air-gapped, SELinux-enforcing
+    # RHEL-family hosts set both true so a missing k3s-selinux policy does not
+    # abort the offline install:
+    # k3s_skip_selinux_rpm: true   # never reach the package manager for k3s-selinux
+    # k3s_selinux_warn: true       # missing SELinux policy -> warning instead of fatal
+
+  roles:
+    - role: deploy-configure-rke
+EOF
+
+ansible-playbook -i inv play.yaml -vv
+```
+
+</details>
+
 <details><summary>EXAMPLE K3S PLAYBOOK w/ ADDONS</summary>
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ cat <<EOF > ./play.yaml
   vars:
     install_k3s: true
     k3s_state: present #absent
-    k3s_k8s_version: 1.31.1
+    k3s_k8s_version: 1.36.1
     k3s_release_kind: k3s1
     cluster_setup: singlenode
     install_cillium: true
@@ -380,7 +380,7 @@ cat <<EOF > ./play.yaml
   vars:
     install_k3s: true
     k3s_state: present #absent
-    k3s_k8s_version: 1.31.1
+    k3s_k8s_version: 1.36.1
     k3s_release_kind: k3s1
     cluster_setup: singlenode
     install_cillium: true

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -131,6 +131,14 @@ k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
 k3s_airgapped_image_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k3s_k8s_version }}%2B{{ k3s_release_kind }}/{{ k3s_airgapped_archive }}"
 # Optional checksum (e.g. "sha256:<hash>" or "sha256:<url>"); unset by default.
 # k3s_airgapped_checksum: "sha256:..."
+# Fully-offline binary install: when k3s_airgapped_installation is true the k3s
+# binary is fetched from k3s_airgapped_binary_url to k3s_airgapped_binary_dest and
+# the install script runs with INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream pull).
+# Override k3s_airgapped_binary_url to a mirror/locally hosted binary as needed.
+k3s_airgapped_binary_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k3s_k8s_version }}%2B{{ k3s_release_kind }}/k3s"
+k3s_airgapped_binary_dest: /usr/local/bin/k3s
+# Optional checksum for the k3s binary; unset by default.
+# k3s_airgapped_binary_checksum: "sha256:..."
 k3s_path_to_generated_token: /var/lib/rancher/k3s/server/node-token
 k3s_master_ip: "{{ groups.initial_master_node | map('extract', hostvars, 'ansible_default_ipv4') | map(attribute='address') }}"
 k3s_additional_nodes: "{{ groups.additional_master_nodes | map('extract', hostvars) | map(attribute='ansible_hostname') }}"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -118,9 +118,19 @@ helm_binary:
 install_k3s: false
 k3s_state: absent
 k3s_installscript_url: https://get.k3s.io
-k3s_k8s_version: 1.24.13
+k3s_k8s_version: 1.36.1
 k3s_release_kind: k3s1
 k3s_version: "v{{ k3s_k8s_version }}+{{ k3s_release_kind }}"
+# k3s air-gapped image archive (mirrors the rke2_airgapped_* vars).
+# Disabled by default; set k3s_airgapped_installation: true to pre-seed images.
+k3s_airgapped_installation: false
+k3s_airgapped_archive: k3s-airgap-images-amd64.tar.zst
+k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
+# Override k3s_airgapped_image_url to point at any mirror/host, e.g. a locally
+# hosted .zst. Defaults to the upstream k3s-io release for the pinned version.
+k3s_airgapped_image_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k3s_k8s_version }}%2B{{ k3s_release_kind }}/{{ k3s_airgapped_archive }}"
+# Optional checksum (e.g. "sha256:<hash>" or "sha256:<url>"); unset by default.
+# k3s_airgapped_checksum: "sha256:..."
 k3s_path_to_generated_token: /var/lib/rancher/k3s/server/node-token
 k3s_master_ip: "{{ groups.initial_master_node | map('extract', hostvars, 'ansible_default_ipv4') | map(attribute='address') }}"
 k3s_additional_nodes: "{{ groups.additional_master_nodes | map('extract', hostvars) | map(attribute='ansible_hostname') }}"

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -139,6 +139,14 @@ k3s_airgapped_binary_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k
 k3s_airgapped_binary_dest: /usr/local/bin/k3s
 # Optional checksum for the k3s binary; unset by default.
 # k3s_airgapped_binary_checksum: "sha256:..."
+# SELinux toggles for the k3s install script (default false -> upstream behaviour
+# unchanged). On air-gapped SELinux-enforcing (RHEL-family) hosts set both true:
+#   k3s_skip_selinux_rpm -> INSTALL_K3S_SKIP_SELINUX_RPM, never reach the package
+#     manager to install k3s-selinux (avoids repo/network access for the policy).
+#   k3s_selinux_warn     -> INSTALL_K3S_SELINUX_WARN, demote a missing SELinux
+#     policy from a fatal error to a warning so the offline install can complete.
+k3s_skip_selinux_rpm: false
+k3s_selinux_warn: false
 k3s_path_to_generated_token: /var/lib/rancher/k3s/server/node-token
 k3s_master_ip: "{{ groups.initial_master_node | map('extract', hostvars, 'ansible_default_ipv4') | map(attribute='address') }}"
 k3s_additional_nodes: "{{ groups.additional_master_nodes | map('extract', hostvars) | map(attribute='ansible_hostname') }}"

--- a/molecule/k3s/k3s.yaml
+++ b/molecule/k3s/k3s.yaml
@@ -7,7 +7,7 @@
   vars:
     install_k3s: true
     k3s_state: present #absent #present #absent
-    k3s_k8s_version: 1.33.4
+    k3s_k8s_version: 1.36.1
     k3s_release_kind: k3s1
     cluster_setup: multinode
     install_cillium: true

--- a/tasks/deploy-k3s.yaml
+++ b/tasks/deploy-k3s.yaml
@@ -24,6 +24,8 @@
     # When air-gapped, the binary is pre-staged at k3s_airgapped_binary_dest and
     # the install script skips the upstream download. "false" keeps default behaviour.
     INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
+    INSTALL_K3S_SKIP_SELINUX_RPM: "{{ 'true' if k3s_skip_selinux_rpm | bool else 'false' }}"
+    INSTALL_K3S_SELINUX_WARN: "{{ 'true' if k3s_selinux_warn | bool else 'false' }}"
   when: inventory_hostname in groups['initial_master_node']
 
 - name: Read k3s token from inital master
@@ -53,6 +55,8 @@
     K3S_TOKEN: "{{ k3s_shared_token }}"
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
     INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
+    INSTALL_K3S_SKIP_SELINUX_RPM: "{{ 'true' if k3s_skip_selinux_rpm | bool else 'false' }}"
+    INSTALL_K3S_SELINUX_WARN: "{{ 'true' if k3s_selinux_warn | bool else 'false' }}"
   when: inventory_hostname in groups['additional_master_nodes']
 
 - name: Label worker nodes

--- a/tasks/deploy-k3s.yaml
+++ b/tasks/deploy-k3s.yaml
@@ -21,6 +21,9 @@
     curl -sfL {{ k3s_installscript_url }} | sh -s - --config={{ k3s_config_dir }}/{{ k3s_config_name }}
   environment:
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    # When air-gapped, the binary is pre-staged at k3s_airgapped_binary_dest and
+    # the install script skips the upstream download. "false" keeps default behaviour.
+    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
   when: inventory_hostname in groups['initial_master_node']
 
 - name: Read k3s token from inital master
@@ -49,6 +52,7 @@
     K3S_URL: "https://{{ k3s_master_ip[0] }}:6443"
     K3S_TOKEN: "{{ k3s_shared_token }}"
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
   when: inventory_hostname in groups['additional_master_nodes']
 
 - name: Label worker nodes

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -50,6 +50,16 @@
         validate_certs: "{{ validate_certs }}"
         checksum: "{{ k3s_airgapped_checksum | default(omit) }}"
 
+    - name: Download k3s binary for offline install
+      ansible.builtin.get_url:
+        url: "{{ k3s_airgapped_binary_url }}"
+        dest: "{{ k3s_airgapped_binary_dest }}"
+        owner: "{{ rke2_user_name }}"
+        group: "{{ rke2_user_group }}"
+        mode: "0755"
+        validate_certs: "{{ validate_certs }}"
+        checksum: "{{ k3s_airgapped_binary_checksum | default(omit) }}"
+
   when: k3s_airgapped_installation|bool and install_k3s|bool and k3s_state == "present"
 
 - name: Deploy rke{{ rke_version }}

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -33,6 +33,25 @@
 
   when: rke2_airgapped_installation|bool and not install_k3s and rke_state == "present"
 
+- name: Download air-gapped container images for k3s
+  block:
+
+    - name: Create k3s air-gapped image dir
+      ansible.builtin.file:
+        path: "{{ k3s_airgapped_install_dir }}"
+        state: directory
+        owner: "{{ rke2_user_name }}"
+        group: "{{ rke2_user_group }}"
+
+    - name: Download k3s air-gapped image archive
+      ansible.builtin.get_url:
+        url: "{{ k3s_airgapped_image_url }}"
+        dest: "{{ k3s_airgapped_install_dir }}/{{ k3s_airgapped_archive }}"
+        validate_certs: "{{ validate_certs }}"
+        checksum: "{{ k3s_airgapped_checksum | default(omit) }}"
+
+  when: k3s_airgapped_installation|bool and install_k3s|bool and k3s_state == "present"
+
 - name: Deploy rke{{ rke_version }}
   ansible.builtin.include_tasks: "deploy-rke{{ rke_version }}.yaml"
   when: rke_state == "present" and not install_k3s


### PR DESCRIPTION
## What

k3s-focused changes, all backwards-compatible (defaults preserved, air-gapped path disabled by default).

### 1. Bump default k3s version to `v1.36.1+k3s1`
- `k3s_k8s_version`: `1.24.13` → `1.36.1` (release kind already `k3s1`), tracking upstream [k3s v1.36.1+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.36.1%2Bk3s1) (Kubernetes v1.36.1).
- Bumps the k3s molecule scenario override (`molecule/k3s/k3s.yaml`) to `1.36.1` so the test exercises the shipped default.

### 2. Overridable k3s air-gapped install (images **and** binary) — new
k3s previously had **no** air-gapped handling (rke2-only). This adds it, mirroring the `rke2_airgapped_*` pattern, and supports a **fully-offline** install:

| var | default |
|---|---|
| `k3s_airgapped_installation` | `false` |
| `k3s_airgapped_archive` | `k3s-airgap-images-amd64.tar.zst` |
| `k3s_airgapped_install_dir` | `/var/lib/rancher/k3s/agent/images/` |
| `k3s_airgapped_image_url` | upstream release for the pinned version (overridable) |
| `k3s_airgapped_checksum` | unset (optional) |
| `k3s_airgapped_binary_url` | upstream `k3s` binary for the pinned version (overridable) |
| `k3s_airgapped_binary_dest` | `/usr/local/bin/k3s` |
| `k3s_airgapped_binary_checksum` | unset (optional) |
| `k3s_skip_selinux_rpm` | `false` |
| `k3s_selinux_warn` | `false` |

When `k3s_airgapped_installation: true`, the air-gapped block in `tasks/main.yaml` (gated on `install_k3s and k3s_state == "present"`) runs **before** deploy and:
- pre-seeds the images archive into `/var/lib/rancher/k3s/agent/images/`, and
- pre-stages the executable k3s binary at `/usr/local/bin/k3s`.

`tasks/deploy-k3s.yaml` then passes `INSTALL_K3S_SKIP_DOWNLOAD` to both the server and additional-node installs — `true` when air-gapped (the install script uses the pre-staged binary, no upstream pull), `false` otherwise (unchanged behaviour). Verified against the upstream install.sh: `INSTALL_K3S_SKIP_DOWNLOAD=true` skips the binary download and requires an executable `/usr/local/bin/k3s` (which we stage); images in the agent dir are loaded regardless; `INSTALL_K3S_VERSION` is not required when skipping.

All URLs/checksums are overridable, so the images, the binary, and the install script (`k3s_installscript_url`) can each point at a mirror or locally hosted artifact for a fully offline run. Optional `checksum: "{{ ... | default(omit) }}"` on each download fails loudly on truncation.

**SELinux (enforcing RHEL-family hosts).** With `INSTALL_K3S_SKIP_DOWNLOAD=true` the SELinux RPM download *and* package-manager install are already skipped (verified against upstream `install.sh`), but on an **enforcing** host a missing policy is still fatal. Two toggles cover this, both default `false` (no behaviour change):
- `k3s_skip_selinux_rpm` → `INSTALL_K3S_SKIP_SELINUX_RPM`: never reach the package manager for `k3s-selinux`.
- `k3s_selinux_warn` → `INSTALL_K3S_SELINUX_WARN`: demote a missing SELinux policy from fatal to a warning so an offline install can complete.

Set both `true` for a fully-offline install on enforcing RHEL hosts (pre-install the `k3s-selinux` policy out of band if you need enforcement).

Example consumer config:
```yaml
k3s_airgapped_installation: true
k3s_airgapped_image_url: "https://your-host/k3s-airgap-images-amd64.tar.zst"
k3s_airgapped_binary_url: "https://your-host/k3s"
k3s_installscript_url: "https://your-host/k3s-install.sh"   # optional, for zero-egress
```

## Testing
- ✅ `ansible-playbook --syntax-check` on both the k3s and rke2 molecule plays — clean, no regression.
- ✅ Confirmed default image URL renders as `…/v1.36.1%2Bk3s1/k3s-airgap-images-amd64.tar.zst` and `INSTALL_K3S_SKIP_DOWNLOAD` renders lowercase `true`/`false`.
- ✅ Cross-checked `INSTALL_K3S_SKIP_DOWNLOAD` semantics against the current upstream `install.sh`.
- ⚠️ Molecule `converge` was **NOT** run: the k3s scenario uses `driver: default, managed: False` against the real host `10.100.136.138`, unreachable from the authoring environment. Please run `molecule test -s k3s` against the live host before merging. A real air-gapped run is the only way to exercise the `SKIP_DOWNLOAD` + pre-staged-binary path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)