### PR TITLE
feat: bump default rke2 to v1.36.1+rke2r2

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -22,7 +22,7 @@ kubeconfig_mode_644: true
 rke2_type: server
 rke2_imagelist: rke2-images-all.linux-amd64.txt
 rke2_imagelist_url: "https://github.com/rancher/rke2/releases/download/v{{ rke2_k8s_version }}%2B{{ rke2_release_kind }}/{{ rke2_imagelist }}"
-rke2_k8s_version: 1.35.0
+rke2_k8s_version: 1.36.1
 rke2_version: "v{{ rke2_k8s_version }}+{{ rke2_release_kind }}"
 rke2_channel: stable
 rke2_channel_url: https://update.rke2.io/v1-release/channels
@@ -42,7 +42,7 @@ fetched_kubeconfig_path: ./kubeconfig
 restart_rke2_already_running: true
 rke2_path_to_generated_token: "{{ rke_dir }}/server/node-token"
 rke2_additional_manifests_path: "{{ rke_dir }}/server/manifests"
-rke2_release_kind: rke2r3 #rke2r2 +rke2r1
+rke2_release_kind: rke2r2 #rke2r3 +rke2r1
 rke2_airgapped_image_url: "https://github.com/rancher/rke2/releases/download/v{{ rke2_k8s_version }}%2B{{ rke2_release_kind }}/{{ rke2_airgapped_archive }}"
 rke2_airgapped_installation: false
 rke2_airgapped_install_dir: "{{ rke_dir }}/agent/images/"


### PR DESCRIPTION
## What

Bump the default rke2 version to **`v1.36.1+rke2r2`** (Kubernetes v1.36.1).

- `rke2_k8s_version`: `1.35.0` → `1.36.1`
- `rke2_release_kind`: `rke2r3` → `rke2r2`

`rke2_version`, `rke2_airgapped_image_url`, and `rke2_imagelist_url` all derive from these and now resolve to the v1.36.1+rke2r2 artifacts, e.g.:
- `…/v1.36.1%2Brke2r2/rke2-images.linux-amd64.tar.zst`
- `…/v1.36.1%2Brke2r2/rke2-images-all.linux-amd64.txt`

## Upstream behaviour change to be aware of (Traefik ↔ ingress-nginx)
Per the [v1.36.1+rke2r2 release notes](https://github.com/rancher/rke2/releases/tag/v1.36.1%2Brke2r2): ingress-nginx was retired upstream (2026-03), so **Traefik is now the default ingress for new v1.36 clusters** (existing clusters keep their current ingress on upgrade).

- This role already disables `rke2-ingress-nginx` via `disable_rke2_components`, so on new clusters Traefik becomes the default ingress. No role change needed for that.
- **Air-gapped:** the `rke2-images-core` tarball now ships Traefik images instead of ingress-nginx, and the standalone `rke2-images-traefik` tarball was removed. Clusters that still require ingress-nginx must supply the `rke2-images-ingress-nginx` tarball — override `rke2_airgapped_archive` / `rke2_airgapped_image_url` to point at it.
- ingress-nginx will be fully removed in v1.37 for community users.

## Testing
- ✅ YAML parse + `ansible-playbook --syntax-check` on the rke2 molecule play — clean.
- ✅ Confirmed the derived `rke2_version` and release URLs resolve to `v1.36.1+rke2r2`.
- ⚠️ Molecule `converge` **NOT** run: the rke2 scenario uses `driver: default, managed: False` against the real host `10.31.103.33`, unreachable from the authoring environment. Please run `molecule test -s rke2` against the live host before merging. Note the rke2 molecule scenario pins its own `rke2_k8s_version: 1.33.4` / `rke2_release_kind: rke2r1`, so it won't exercise the new default unless those overrides are bumped too (happy to do that on request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
