### PR TITLE
feat: bump cilium-cli (0.19.4), kubectl (v1.36.1), helm (4.2.0)

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -64,9 +64,9 @@ install_kubectl: true
 install_helm: true
 
 install_cilium: true
-cilium_version: 0.19.0
-kubectl_version: v1.35.1
-helm_version: 4.1.1
+cilium_version: 0.19.4
+kubectl_version: v1.36.1
+helm_version: 4.2.0
 
 disableKubeProxy: false
 rke2_kube_proxy_file: /var/lib/rancher/rke2/agent/pod-manifests/kube-proxy.yaml


### PR DESCRIPTION
## What

Bump three addon tool versions to latest:

| var | old | new | drives |
|---|---|---|---|
| `cilium_version` | `0.19.0` | `0.19.4` | cilium-CLI release tarball |
| `kubectl_version` | `v1.35.1` | `v1.36.1` | kubectl binary (now matches the k8s v1.36.1 line) |
| `helm_version` | `4.1.1` | `4.2.0` | helm release tarball |

Note the var conventions differ and are preserved: `kubectl_version` keeps its `v` prefix (used directly in `https://dl.k8s.io/{{ kubectl_version }}/...`), while `helm_version` and `cilium_version` are bare (the `v` is added in their URL templates). `cilium_version` here is the **cilium-CLI** version, not the Cilium chart/agent (`cilium_gateway_api_crds_version` etc. are untouched).

## Testing
- ✅ Latest versions resolved from authoritative sources: `dl.k8s.io/release/stable.txt` (kubectl), `helm/helm` + `cilium/cilium-cli` GitHub latest releases.
- ✅ HEAD-checked the resulting download URLs — all return **HTTP 200**:
  - `https://dl.k8s.io/v1.36.1/bin/linux/amd64/kubectl`
  - `https://get.helm.sh/helm-v4.2.0-linux-amd64.tar.gz`
  - `https://github.com/cilium/cilium-cli/releases/download/v0.19.4/cilium-linux-amd64.tar.gz`
- ✅ YAML parse + `ansible-playbook --syntax-check` (rke2 play) clean.
- ⚠️ Molecule `converge` not run (target hosts unreachable from the authoring environment) — these are install-time binary fetches, so run a scenario against a live host before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)