### PR TITLE
feat: version bumps — rke2 v1.36.1+rke2r2, kubectl v1.36.1, helm 4.2.0, cilium-cli 0.19.4

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -70,9 +70,9 @@ install_kubectl: true
 install_helm: true
 
 install_cilium: true
-cilium_version: 0.19.0
-kubectl_version: v1.35.1
-helm_version: 4.1.1
+cilium_version: 0.19.4
+kubectl_version: v1.36.1
+helm_version: 4.2.0
 
 disableKubeProxy: false
 rke2_kube_proxy_file: /var/lib/rancher/rke2/agent/pod-manifests/kube-proxy.yaml

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -22,7 +22,7 @@ kubeconfig_mode_644: true
 rke2_type: server
 rke2_imagelist: rke2-images-all.linux-amd64.txt
 rke2_imagelist_url: "https://github.com/rancher/rke2/releases/download/v{{ rke2_k8s_version }}%2B{{ rke2_release_kind }}/{{ rke2_imagelist }}"
-rke2_k8s_version: 1.35.0
+rke2_k8s_version: 1.36.1
 rke2_version: "v{{ rke2_k8s_version }}+{{ rke2_release_kind }}"
 rke2_channel: stable
 rke2_channel_url: https://update.rke2.io/v1-release/channels
@@ -44,7 +44,7 @@ fetched_kubeconfig_path: ./kubeconfig
 restart_rke2_already_running: true
 rke2_path_to_generated_token: "{{ rke_dir }}/server/node-token"
 rke2_additional_manifests_path: "{{ rke_dir }}/server/manifests"
-rke2_release_kind: rke2r3 #rke2r2 +rke2r1
+rke2_release_kind: rke2r2 #rke2r3 +rke2r1
 rke2_airgapped_image_url: "https://github.com/rancher/rke2/releases/download/v{{ rke2_k8s_version }}%2B{{ rke2_release_kind }}/{{ rke2_airgapped_archive }}"
 rke2_airgapped_installation: false
 rke2_airgapped_install_dir: "{{ rke_dir }}/agent/images/"


### PR DESCRIPTION
## What

Consolidates the two version-bump PRs (#22 rke2, #23 cilium-cli/kubectl/helm) into one. Rebased on top of `main` (which already includes the merged readiness-gate PR #20).

| var | old | new | drives |
|---|---|---|---|
| `rke2_k8s_version` | `1.35.0` | `1.36.1` | rke2 release (k8s v1.36.1) |
| `rke2_release_kind` | `rke2r3` | `rke2r2` | rke2 release kind |
| `kubectl_version` | `v1.35.1` | `v1.36.1` | kubectl binary (keeps `v` prefix) |
| `helm_version` | `4.1.1` | `4.2.0` | helm tarball (bare, `v` added in URL) |
| `cilium_version` | `0.19.0` | `0.19.4` | cilium-**CLI** tarball (bare; not the Cilium chart) |

## Upstream note (rke2 v1.36 — Traefik)
ingress-nginx was retired upstream (2026-03); Traefik is the default ingress for new v1.36 clusters. This role already disables `rke2-ingress-nginx`, so Traefik becomes default — no code change. Air-gapped clusters needing ingress-nginx must now supply the `rke2-images-ingress-nginx` tarball (the standalone traefik tarball was removed upstream).

## Testing
- ✅ Latest versions resolved from authoritative sources (`dl.k8s.io/release/stable.txt`, helm/cilium-cli GitHub releases).
- ✅ HEAD-checked all new download URLs → HTTP 200 (kubectl v1.36.1, helm-v4.2.0, cilium-cli v0.19.4).
- ✅ Derived `rke2_version` / air-gapped / image-list URLs resolve to `v1.36.1+rke2r2`.
- ✅ YAML parse + `ansible-playbook --syntax-check` (rke2 play) clean.
- ⚠️ Molecule `converge` not run (target hosts unreachable from the authoring environment). Run a scenario against a live host before merging.

Supersedes #22 and #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)