### PR TITLE
feat: k3s registry pull-through mirror + decouple air-gapped images from offline binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,26 +337,42 @@ cat <<EOF > ./play.yaml
     cluster_setup: singlenode
     install_cillium: true
 
-    # --- air-gapped install -------------------------------------------------
-    # Pre-stage the images archive AND the k3s binary, then run the install
-    # script with INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream pull).
+    # --- air-gapped images (independent of the binary path) -----------------
+    # Pre-seed the images archive into /var/lib/rancher/k3s/agent/images/.
+    # IMAGES ONLY: the k3s binary + install script are still pulled normally.
     k3s_airgapped_installation: true
-
-    # Optional overrides (each defaults to the upstream release for the pinned
-    # version). Point them at a mirror / locally hosted artifact for a fully
-    # offline run:
+    # Point the archive at your mirror (e.g. a public S3/MinIO object):
     # k3s_airgapped_image_url: "https://your-host/k3s-airgap-images-amd64.tar.zst"
     # k3s_airgapped_archive: k3s-airgap-images-amd64.tar.zst
     # k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
     # k3s_airgapped_checksum: "sha256:..."          # optional, verifies the archive
+
+    # --- offline binary (optional, independent of images) -------------------
+    # Set true to ALSO stage the k3s binary and run the install script with
+    # INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream binary pull). Leave false for
+    # an images-only air-gap where the host still has egress for the binary.
+    # k3s_airgapped_skip_download: true
     # k3s_airgapped_binary_url: "https://your-host/k3s"
     # k3s_airgapped_binary_dest: /usr/local/bin/k3s
     # k3s_airgapped_binary_checksum: "sha256:..."   # optional, verifies the binary
     # k3s_installscript_url: "https://your-host/k3s-install.sh"  # for zero egress
 
+    # --- registry pull-through mirror (writes /etc/rancher/k3s/registries.yaml) ---
+    k3s_registry_mirrors:
+      - name: "docker.io"
+        endpoints:
+          - "https://docker.harbor.example.com"
+          - "https://registry-1.docker.io"   # fallback
+    # k3s_registry_configs:            # optional auth / TLS per registry host
+    #   "docker.harbor.example.com":
+    #     username: "robot\$puller"
+    #     password: "<secret>"
+    #     tls:
+    #       insecure_skip_verify: false
+
     # SELinux toggles (default false). On air-gapped, SELinux-enforcing
     # RHEL-family hosts set both true so a missing k3s-selinux policy does not
-    # abort the offline install:
+    # abort the offline install (requires k3s_airgapped_skip_download):
     # k3s_skip_selinux_rpm: true   # never reach the package manager for k3s-selinux
     # k3s_selinux_warn: true       # missing SELinux policy -> warning instead of fatal
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -122,7 +122,9 @@ k3s_k8s_version: 1.36.1
 k3s_release_kind: k3s1
 k3s_version: "v{{ k3s_k8s_version }}+{{ k3s_release_kind }}"
 # k3s air-gapped image archive (mirrors the rke2_airgapped_* vars).
-# Disabled by default; set k3s_airgapped_installation: true to pre-seed images.
+# Disabled by default; set k3s_airgapped_installation: true to pre-seed the
+# images archive into k3s_airgapped_install_dir. This controls IMAGES ONLY and
+# is independent of the offline-binary path (k3s_airgapped_skip_download below).
 k3s_airgapped_installation: false
 k3s_airgapped_archive: k3s-airgap-images-amd64.tar.zst
 k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
@@ -131,14 +133,31 @@ k3s_airgapped_install_dir: /var/lib/rancher/k3s/agent/images/
 k3s_airgapped_image_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k3s_k8s_version }}%2B{{ k3s_release_kind }}/{{ k3s_airgapped_archive }}"
 # Optional checksum (e.g. "sha256:<hash>" or "sha256:<url>"); unset by default.
 # k3s_airgapped_checksum: "sha256:..."
-# Fully-offline binary install: when k3s_airgapped_installation is true the k3s
-# binary is fetched from k3s_airgapped_binary_url to k3s_airgapped_binary_dest and
-# the install script runs with INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream pull).
+# Offline binary install (independent of the images path above). When
+# k3s_airgapped_skip_download is true, the k3s binary is fetched from
+# k3s_airgapped_binary_url to k3s_airgapped_binary_dest and the install script
+# runs with INSTALL_K3S_SKIP_DOWNLOAD=true (no upstream binary pull). Leave false
+# to let the install script download the binary normally (e.g. images-only
+# air-gap where the host still has egress for the k3s binary + install script).
+k3s_airgapped_skip_download: false
 # Override k3s_airgapped_binary_url to a mirror/locally hosted binary as needed.
 k3s_airgapped_binary_url: "https://github.com/k3s-io/k3s/releases/download/v{{ k3s_k8s_version }}%2B{{ k3s_release_kind }}/k3s"
 k3s_airgapped_binary_dest: /usr/local/bin/k3s
 # Optional checksum for the k3s binary; unset by default.
 # k3s_airgapped_binary_checksum: "sha256:..."
+# k3s registry mirrors / pull-through (writes /etc/rancher/k3s/registries.yaml
+# before install when defined). Mirror docker.io to a harbor pull-through cache:
+#   k3s_registry_mirrors:
+#     - name: "docker.io"
+#       endpoints:
+#         - "https://docker.harbor.example.com"
+#   k3s_registry_configs:            # optional auth / TLS per registry host
+#     "docker.harbor.example.com":
+#       username: robot$puller
+#       password: "<secret>"
+#       tls:
+#         insecure_skip_verify: false   # set true to skip cert verification
+#         # ca_file: /etc/ssl/certs/harbor-ca.crt
 # SELinux toggles for the k3s install script (default false -> upstream behaviour
 # unchanged). On air-gapped SELinux-enforcing (RHEL-family) hosts set both true:
 #   k3s_skip_selinux_rpm -> INSTALL_K3S_SKIP_SELINUX_RPM, never reach the package

--- a/tasks/deploy-k3s.yaml
+++ b/tasks/deploy-k3s.yaml
@@ -16,14 +16,25 @@
     src: "{{ k3s_config_template }}"
     dest: "{{ k3s_config_dir }}/{{ k3s_config_name }}"
 
+# registries.yaml must exist before k3s starts so mirrors/pull-through apply.
+- name: Configure k3s registries (mirrors / pull-through)
+  ansible.builtin.template:
+    src: k3s-registries.yaml.j2
+    dest: "{{ k3s_config_dir }}/registries.yaml"
+    owner: "{{ rke2_user_name }}"
+    group: "{{ rke2_user_group }}"
+    mode: "0644"
+  when: k3s_registry_mirrors is defined or k3s_registry_configs is defined
+
 - name: Install k3s-server service and the k3s binary
   ansible.builtin.shell: |
     curl -sfL {{ k3s_installscript_url }} | sh -s - --config={{ k3s_config_dir }}/{{ k3s_config_name }}
   environment:
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
-    # When air-gapped, the binary is pre-staged at k3s_airgapped_binary_dest and
-    # the install script skips the upstream download. "false" keeps default behaviour.
-    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
+    # Offline binary: when k3s_airgapped_skip_download is set, the binary is
+    # pre-staged at k3s_airgapped_binary_dest and the install script skips the
+    # upstream download. "false" keeps the default (script downloads the binary).
+    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_skip_download | bool else 'false' }}"
     INSTALL_K3S_SKIP_SELINUX_RPM: "{{ 'true' if k3s_skip_selinux_rpm | bool else 'false' }}"
     INSTALL_K3S_SELINUX_WARN: "{{ 'true' if k3s_selinux_warn | bool else 'false' }}"
   when: inventory_hostname in groups['initial_master_node']
@@ -54,7 +65,7 @@
     K3S_URL: "https://{{ k3s_master_ip[0] }}:6443"
     K3S_TOKEN: "{{ k3s_shared_token }}"
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
-    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_installation | bool else 'false' }}"
+    INSTALL_K3S_SKIP_DOWNLOAD: "{{ 'true' if k3s_airgapped_skip_download | bool else 'false' }}"
     INSTALL_K3S_SKIP_SELINUX_RPM: "{{ 'true' if k3s_skip_selinux_rpm | bool else 'false' }}"
     INSTALL_K3S_SELINUX_WARN: "{{ 'true' if k3s_selinux_warn | bool else 'false' }}"
   when: inventory_hostname in groups['additional_master_nodes']

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -33,15 +33,17 @@
 
   when: rke2_airgapped_installation|bool and not install_k3s and rke_state == "present"
 
-- name: Download air-gapped container images for k3s
+- name: Stage k3s air-gapped artifacts
   block:
 
+    # Images: pre-seed the agent images dir (k3s_airgapped_installation).
     - name: Create k3s air-gapped image dir
       ansible.builtin.file:
         path: "{{ k3s_airgapped_install_dir }}"
         state: directory
         owner: "{{ rke2_user_name }}"
         group: "{{ rke2_user_group }}"
+      when: k3s_airgapped_installation | bool
 
     - name: Download k3s air-gapped image archive
       ansible.builtin.get_url:
@@ -49,7 +51,10 @@
         dest: "{{ k3s_airgapped_install_dir }}/{{ k3s_airgapped_archive }}"
         validate_certs: "{{ validate_certs }}"
         checksum: "{{ k3s_airgapped_checksum | default(omit) }}"
+      when: k3s_airgapped_installation | bool
 
+    # Binary: only when the install script skips the upstream download
+    # (k3s_airgapped_skip_download) -> stage an executable k3s at the dest.
     - name: Download k3s binary for offline install
       ansible.builtin.get_url:
         url: "{{ k3s_airgapped_binary_url }}"
@@ -59,8 +64,12 @@
         mode: "0755"
         validate_certs: "{{ validate_certs }}"
         checksum: "{{ k3s_airgapped_binary_checksum | default(omit) }}"
+      when: k3s_airgapped_skip_download | bool
 
-  when: k3s_airgapped_installation|bool and install_k3s|bool and k3s_state == "present"
+  when:
+    - install_k3s | bool
+    - k3s_state == "present"
+    - k3s_airgapped_installation | bool or k3s_airgapped_skip_download | bool
 
 - name: Deploy rke{{ rke_version }}
   ansible.builtin.include_tasks: "deploy-rke{{ rke_version }}.yaml"

--- a/templates/k3s-registries.yaml.j2
+++ b/templates/k3s-registries.yaml.j2
@@ -1,0 +1,31 @@
+---
+{% if k3s_registry_configs is defined %}
+configs:
+{% for host, cfg in k3s_registry_configs.items() %}
+  "{{ host }}":
+{% if cfg.username is defined %}
+    auth:
+      username: {{ cfg.username }}
+      password: {{ cfg.password }}
+{% endif %}
+{% if cfg.tls is defined %}
+    tls:
+{% if cfg.tls.insecure_skip_verify is defined %}
+      insecure_skip_verify: {{ cfg.tls.insecure_skip_verify | string | lower }}
+{% endif %}
+{% if cfg.tls.ca_file is defined %}
+      ca_file: {{ cfg.tls.ca_file }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if k3s_registry_mirrors is defined %}
+mirrors:
+{% for mirror in k3s_registry_mirrors %}
+  "{{ mirror.name }}":
+    endpoint:
+{% for ep in mirror.endpoints %}
+      - "{{ ep }}"
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## What

Two k3s improvements, both backwards-compatible (new behaviour off/opt-in by default), **validated end-to-end on a real single-node VM** (see below).

### 1. k3s registry pull-through mirror support (new)
k3s previously had **no** registry-mirror support — `configure-registries.yaml` only ran in the rke2 path and wrote to `/etc/rancher/rke2`. This adds it for k3s:
- New `templates/k3s-registries.yaml.j2` and a task in `deploy-k3s.yaml` that writes `/etc/rancher/k3s/registries.yaml` **before** install, when `k3s_registry_mirrors` / `k3s_registry_configs` are defined.
- Supports mirrors plus optional per-host `auth` and `tls` (`insecure_skip_verify` / `ca_file`).

### 2. Decouple air-gapped images from offline-binary install
The merged behaviour coupled images + binary + `INSTALL_K3S_SKIP_DOWNLOAD` under one flag. Split into two independent controls:
- `k3s_airgapped_installation` → **images only** (pre-seed the archive).
- `k3s_airgapped_skip_download` (new, default false) → stage the binary + set `INSTALL_K3S_SKIP_DOWNLOAD`.

This enables the common "images-only air-gap" case (mirror the images, let the host pull the k3s binary/install script from upstream) without forcing the offline-binary path. `deploy-k3s.yaml` now gates `INSTALL_K3S_SKIP_DOWNLOAD` on the new var. README updated for the split + the registry mirror.

## Live validation (single-node VM, 10.31.101.104)
Deployed with: latest k3s, air-gapped **images pulled from a public S3/MinIO mirror**, and a `docker.io` → harbor **pull-through mirror** (anonymous, no auth). Verified on the node:

| Check | Result |
|---|---|
| Node | `Ready` (control-plane,etcd) |
| Version | `v1.36.1+k3s1` |
| `/etc/rancher/k3s/registries.yaml` | written with the docker.io → harbor mirror (+ upstream fallback) |
| Air-gap images | `k3s-airgap-images-amd64.tar.zst` (243,600,715 B, byte-exact to the mirror object) staged in the agent images dir |
| Core pods | coredns + cilium/cilium-envoy/cilium-operator Running |

Pre-flight: harbor pull-through verified anonymously from the VM (manifest + blob `HTTP 200`); containerd's native anonymous-token flow needs no `k3s_registry_configs`.

## Notes
- Templating: render + `ansible-playbook --syntax-check` (k3s & rke2 plays) clean.
- Surfaced a pre-existing, non-fatal dependency bug during the run (Ubuntu/Debian `install-requirements` "required repo" task) — tracked in stuttgart-things/install-requirements#36, **not** in scope here.
- A local test playbook/inventory exists (`tests/k3s-airgap-mirror.yaml`) but is intentionally **not** included — it carries an env-specific VM IP + S3 URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
