### PR TITLE
fix: clean up leftover Cilium interfaces on k3s/rke2 teardown

### DIFF
--- a/tasks/cleanup-cilium-interfaces.yaml
+++ b/tasks/cleanup-cilium-interfaces.yaml
@@ -1,0 +1,19 @@
+---
+# Cilium is installed out-of-band (cilium-cli) when used as the CNI, so the k3s /
+# rke2 uninstall scripts -- which only clean up their bundled CNI (flannel/canal) --
+# leave Cilium's datapath interfaces behind (cilium_host/cilium_net/cilium_vxlan,
+# and geneve/wireguard/health depending on config). Remove them on teardown.
+# Existence-guarded, so it is a safe no-op when Cilium was not used. Runs on every
+# node because the interfaces are per-node. Deleting cilium_host also removes its
+# veth peer cilium_net, so cilium_net is not listed explicitly.
+- name: Clean up leftover Cilium network interfaces
+  ansible.builtin.shell: |
+    deleted=""
+    for ifc in cilium_host cilium_vxlan cilium_geneve cilium_wg0 lxc_health; do
+      if ip link show "${ifc}" >/dev/null 2>&1; then
+        ip link delete "${ifc}" && deleted="${deleted} ${ifc}"
+      fi
+    done
+    [ -n "${deleted}" ] && echo "deleted:${deleted}" || echo "nothing to delete"
+  register: cilium_iface_cleanup
+  changed_when: "'deleted:' in cilium_iface_cleanup.stdout"

--- a/tasks/remove-k3s.yaml
+++ b/tasks/remove-k3s.yaml
@@ -8,3 +8,6 @@
   ansible.builtin.shell: |
     sh {{ k3s_agent_uninstall_script }}
   when: inventory_hostname in groups['additional_master_nodes']
+
+- name: Clean up leftover Cilium interfaces
+  ansible.builtin.include_tasks: cleanup-cilium-interfaces.yaml

--- a/tasks/remove-rke2.yaml
+++ b/tasks/remove-rke2.yaml
@@ -15,3 +15,6 @@
     path: "{{ rke2_config_dir }}"
     state: absent
   tags: rke2_config
+
+- name: Clean up leftover Cilium interfaces
+  ansible.builtin.include_tasks: cleanup-cilium-interfaces.yaml

--- a/tests/inventory-k3s-airgap.yaml
+++ b/tests/inventory-k3s-airgap.yaml
@@ -1,0 +1,14 @@
+---
+# Single-node k3s test target.
+all:
+  vars:
+    ansible_user: sthings
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+  children:
+    initial_master_node:
+      hosts:
+        10.31.101.104:
+    additional_master_nodes:
+      hosts: {}
+    workers:
+      hosts: {}

--- a/tests/k3s-airgap-mirror.yaml
+++ b/tests/k3s-airgap-mirror.yaml
@@ -1,0 +1,51 @@
+---
+# ----------------------------------------------------------------------------
+# Test: k3s (latest, v1.36.1+k3s1) single-node, with:
+#   * air-gapped IMAGES pulled from a public S3/MinIO mirror (images-only;
+#     the k3s binary + install script still come from upstream)
+#   * a docker.io pull-through MIRROR to harbor (with upstream fallback)
+#
+# Run:
+#   export ANSIBLE_ROLES_PATH=$(dirname "$PWD"):$HOME/.ansible/roles
+#   ansible-playbook -i tests/inventory-k3s-airgap.yaml tests/k3s-airgap-mirror.yaml -vv
+# ----------------------------------------------------------------------------
+- name: Deploy k3s (air-gapped images + pull-through mirror)
+  hosts: all
+  gather_facts: true
+  become: true
+
+  vars:
+    install_k3s: true
+    k3s_state: present
+    k3s_k8s_version: 1.36.1
+    k3s_release_kind: k3s1
+    cluster_setup: singlenode
+    install_cilium: true
+
+    # fetch the kubeconfig back to the control host for verification
+    fetched_kubeconfig_path: /tmp/k3s-airgap-test/kubeconfig
+
+    # --- air-gapped IMAGES from the public S3 mirror (images only) ----------
+    # Binary + install script still pulled from upstream (host has egress).
+    k3s_airgapped_installation: true
+    k3s_airgapped_skip_download: false
+    k3s_airgapped_image_url: "https://artifacts.platform.sthings-vsphere.labul.sva.de/airgap/k3s/v1.36.1-k3s1/k3s-airgap-images-amd64.tar.zst"
+    k3s_airgapped_checksum: "sha256:72cf836bfcf8f9af2de88102b69129d297b77a60243895a7ac4bc47d77a65079"
+    # For a FULLY offline run, also stage the binary from your mirror and flip:
+    # k3s_airgapped_skip_download: true
+    # k3s_airgapped_binary_url: "https://artifacts.platform.sthings-vsphere.labul.sva.de/airgap/k3s/v1.36.1-k3s1/k3s"
+
+    # --- docker.io pull-through mirror -> harbor (fallback to upstream) ------
+    k3s_registry_mirrors:
+      - name: "docker.io"
+        endpoints:
+          - "https://docker.harbor.platform.sthings-vsphere.labul.sva.de"
+          - "https://registry-1.docker.io"
+    # If harbor presents an untrusted cert, uncomment to skip verification:
+    # k3s_registry_configs:
+    #   "docker.harbor.platform.sthings-vsphere.labul.sva.de":
+    #     tls:
+    #       insecure_skip_verify: true
+
+  roles:
+    - role: deploy-configure-rke

--- a/tests/k3s-uninstall.yaml
+++ b/tests/k3s-uninstall.yaml
@@ -1,0 +1,25 @@
+---
+# ----------------------------------------------------------------------------
+# Uninstall k3s via the role's absent path (runs k3s-uninstall.sh on the master).
+# Skips node-prep and kubeconfig fetch so only the removal runs.
+#
+# Run:
+#   export ANSIBLE_ROLES_PATH=$(dirname "$PWD"):$HOME/.ansible/roles
+#   ansible-playbook -i tests/inventory-k3s-airgap.yaml tests/k3s-uninstall.yaml -vv
+# ----------------------------------------------------------------------------
+- name: Uninstall k3s (absent)
+  hosts: all
+  gather_facts: true
+  become: true
+
+  vars:
+    install_k3s: true
+    k3s_state: absent
+    cluster_setup: singlenode
+    # nothing to prep / fetch / install on teardown
+    prepare_rancher_ha_nodes: false
+    fetch_kubeconfig: false
+    install_cilium: false
+
+  roles:
+    - role: deploy-configure-rke


### PR DESCRIPTION
## Problem

The k3s/rke2 uninstall scripts only clean up their **bundled** CNI (flannel/canal). When **Cilium** is the CNI (installed out-of-band via cilium-cli, `rke2_cni`/CNI = none + `install_cilium`), its datapath interfaces survive teardown:

```
cilium_net@cilium_host
cilium_host@cilium_net
cilium_vxlan
```
(plus `cilium_geneve` / `cilium_wg0` / `lxc_health` depending on config). These linger until reboot and can interfere with a same-host re-deploy. Found while testing the k3s `absent` path on a real node.

## Fix

- New `tasks/cleanup-cilium-interfaces.yaml`: deletes the Cilium datapath interfaces. **Existence-guarded** (safe no-op when Cilium wasn't used), runs on **every node** (interfaces are per-node), and `changed_when` only reports changed if something was actually deleted. Deleting `cilium_host` also removes its veth peer `cilium_net`.
- Included at the end of both `remove-k3s.yaml` and `remove-rke2.yaml`.

## Validation (live node, 10.31.101.104)
Run against the leftover interfaces from an actual k3s teardown:
- 1st run → `deleted: cilium_host cilium_vxlan` (changed); `cilium_net` removed with its peer. Afterward: **0** Cilium interfaces remain.
- 2nd run → `nothing to delete` (ok, not changed) → **idempotent**.

YAML validated for all three task files.

## Note
This intentionally does not touch `/usr/bin/kubectl` (the standalone kubectl installed via `install_kubectl` — not a k3s artifact). BPF map / iptables cleanup was left out of scope; the interfaces are the user-visible leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Also adds** the test playbooks used to validate this work on a real single-node host (`tests/k3s-airgap-mirror.yaml`, `tests/k3s-uninstall.yaml`, `tests/inventory-k3s-airgap.yaml`) — no secrets (public mirror URL, anonymous registry).