### PR TITLE
fix: tolerate JSON-string registry vars (dagger -e key=value passing)

### DIFF
--- a/templates/k3s-registries.yaml.j2
+++ b/templates/k3s-registries.yaml.j2
@@ -1,7 +1,12 @@
 ---
-{% if k3s_registry_configs is defined %}
+{# Executors that pass extra-vars as `-e key=value` (e.g. the dagger ansible    #}
+{# module) deliver nested structures as JSON strings. Parse those back with     #}
+{# from_yaml; native list/dict values (e.g. plain ansible-playbook) pass through.#}
+{% set _configs = (k3s_registry_configs | from_yaml) if (k3s_registry_configs is defined and k3s_registry_configs is string) else (k3s_registry_configs | default({})) %}
+{% set _mirrors = (k3s_registry_mirrors | from_yaml) if (k3s_registry_mirrors is defined and k3s_registry_mirrors is string) else (k3s_registry_mirrors | default([])) %}
+{% if _configs %}
 configs:
-{% for host, cfg in k3s_registry_configs.items() %}
+{% for host, cfg in _configs.items() %}
   "{{ host }}":
 {% if cfg.username is defined %}
     auth:
@@ -19,9 +24,9 @@ configs:
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if k3s_registry_mirrors is defined %}
+{% if _mirrors %}
 mirrors:
-{% for mirror in k3s_registry_mirrors %}
+{% for mirror in _mirrors %}
   "{{ mirror.name }}":
     endpoint:
 {% for ep in mirror.endpoints %}

--- a/templates/rke2-registry-config.yaml.j2
+++ b/templates/rke2-registry-config.yaml.j2
@@ -1,7 +1,11 @@
 ---
-{% if rke2_registry_configs is defined %}
+{# Parse JSON-string vars (passed by `-e key=value` executors like dagger) back #}
+{# into structures; native list/dict values pass through unchanged.             #}
+{% set _configs = (rke2_registry_configs | from_yaml) if (rke2_registry_configs is defined and rke2_registry_configs is string) else (rke2_registry_configs | default({})) %}
+{% set _mirrors = (rke2_registry_mirrors | from_yaml) if (rke2_registry_mirrors is defined and rke2_registry_mirrors is string) else (rke2_registry_mirrors | default([])) %}
+{% if _configs %}
 configs:
-{% for cfg in rke2_registry_configs.values() %}
+{% for cfg in _configs.values() %}
   {{ cfg.name }}:
     auth:
       username: {{ cfg.username }}
@@ -9,9 +13,9 @@ configs:
 {% endfor %}
 {% endif %}
 
-{% if rke2_registry_mirrors is defined %}
+{% if _mirrors %}
 mirrors:
-{% for mirror in rke2_registry_mirrors %}
+{% for mirror in _mirrors %}
   "{{ mirror.name }}":
     endpoint:
 {% for ep in mirror.endpoints %}


### PR DESCRIPTION
Registry mirror/config vars arrive as JSON strings when passed via `-e key=value` executors (the dagger ansible module JSON-marshals nested values), causing `'str object' has no attribute 'name'`. Normalize with `from_yaml` when the var is a string; native list/dict pass through unchanged. Validated for native-list, JSON-string, and undefined cases on k3s + rke2 templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)