### PR TITLE
fix: retry cilium upgrade through apiserver transition

### DIFF
--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -5,6 +5,20 @@
     - ansible.builtin.include_role:
         name: download-install-binary
 
+# Run cilium ops only against a stable apiserver. k3s has just started here, so
+# the API can still be flapping; installing/upgrading cilium against it can be
+# interrupted mid-operation and leave the Helm release stuck in pending-upgrade.
+- name: Wait for k8s apiserver to be ready before cilium
+  ansible.builtin.command: kubectl get --raw=/readyz
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  register: cilium_api_readyz
+  until: cilium_api_readyz.rc == 0
+  retries: "{{ cilium_api_ready_retries | default(30) }}"
+  delay: "{{ cilium_api_ready_delay | default(10) }}"
+  changed_when: false
+  when: inventory_hostname in groups['initial_master_node']
+
 - name: Install Gateway API CRDs
   ansible.builtin.command: >
     kubectl apply -f

--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -54,4 +54,12 @@
     cilium status --wait
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
+  register: cilium_upgrade
+  # `cilium install` replaces kube-proxy and reconfigures the datapath, which can
+  # briefly drop the apiserver connection (connection refused / unexpected EOF).
+  # Retry so the upgrade rides through that transition instead of failing the run.
+  until: cilium_upgrade.rc == 0
+  retries: "{{ cilium_upgrade_retries | default(10) }}"
+  delay: "{{ cilium_upgrade_delay | default(15) }}"
+  changed_when: cilium_upgrade.rc == 0
   when: inventory_hostname in groups['initial_master_node']


### PR DESCRIPTION
## Problem
On k3s with Cilium (kube-proxy replacement), `cilium install` reconfigures the datapath and briefly drops the apiserver connection. The very next task, `Upgrade cilium configuration` (`cilium upgrade`), then fails with `dial tcp …:6443: connect: connection refused - unexpected EOF` — even though the cluster converges seconds later (node Ready, all Cilium pods Running).

## Fix
Add `until: rc == 0` with `retries`/`delay` (default **10 × 15s**, overridable via `cilium_upgrade_retries` / `cilium_upgrade_delay`) to the cilium-upgrade task so it rides through the transition instead of failing the run.

Observed on a real dagger provisioning run: registries + k3s + airgap all succeeded (ok=100); only this un-retried task failed on the transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)