### PR TITLE
fix(cilium): set non-overlapping pod CIDR to prevent infra-net black-hole

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -196,6 +196,11 @@ cilium_enable_gateway_api: true
 cilium_gateway_api_crds_version: v1.4.1
 cilium_rollout_pods: true
 cilium_config: cilium.yaml
+# Pod IPAM pool. MUST NOT overlap the node/infrastructure network (e.g. lab 10.31.0.0/16)
+# or Cilium routes pod->infra traffic into the overlay and black-holes it. cilium-cli's
+# default is 10.0.0.0/8, which collides with RFC1918 lab nets — override it here.
+cilium_cluster_pool_ipv4_cidr: 10.42.0.0/16
+cilium_cluster_pool_ipv4_mask_size: 24
 
 create_root_cert: true
 os_cert_path: /usr/local/share/ca-certificates

--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -53,6 +53,8 @@
       --set k8sServiceHost={{ cilium_api_server_ip }} \
       --set k8sServicePort={{ cilium_api_server_port }} \
       --set kubeProxyReplacement={{ cilium_kube_proxy_replacement }} \
+      --set ipam.operator.clusterPoolIPv4PodCIDRList='{{ "{" }}{{ cilium_cluster_pool_ipv4_cidr }}{{ "}" }}' \
+      --set ipam.operator.clusterPoolIPv4MaskSize={{ cilium_cluster_pool_ipv4_mask_size }} \
       --helm-set=operator.replicas={{ cilium_operator_replicas }}
     cilium status --wait
   environment:

--- a/templates/cilium-config.yaml.j2
+++ b/templates/cilium-config.yaml.j2
@@ -13,6 +13,12 @@ k8sClientRateLimit:
   qps: 50
   burst: 200
 
+ipam:
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - {{ cilium_cluster_pool_ipv4_cidr }}
+    clusterPoolIPv4MaskSize: {{ cilium_cluster_pool_ipv4_mask_size }}
+
 operator:
   replicas: {{ cilium_operator_replicas }}
   rollOutPods: {{ cilium_rollout_pods }}


### PR DESCRIPTION
## Problem

cilium-cli defaults the cluster-pool IPAM CIDR to **`10.0.0.0/8`**, which overlaps RFC1918 lab/node networks (e.g. `10.31.0.0/16`). With `ipam: cluster-pool`, Cilium treats infrastructure IPs (DNS, Vault, etc.) as in-overlay pod endpoints and **black-holes pod→infra traffic**.

Observed on the `rke2-airgapped-test` cluster: pods could not resolve DNS (`10.31.101.52/.50`) or reach Vault (`10.31.101.6`) while the node itself could. This cascaded into `vault-pki` ClusterIssuer failing → `test-k3s-gateway-tls` cert never issued → Gateway `:443` listener `Invalid` → all HTTPRoutes unreachable over HTTPS.

## Fix

- Add `cilium_cluster_pool_ipv4_cidr` (default `10.42.0.0/16`) and `cilium_cluster_pool_ipv4_mask_size` (default `24`) to `defaults/main.yaml`. `10.42.0.0/16` is disjoint from the lab net and from the `10.43.0.0/16` service CIDR.
- Wire the pod CIDR into the `cilium install` `--set ipam.operator.*` flags so the pool is correct on first install.
- Add the matching `ipam:` block to `templates/cilium-config.yaml.j2` so `cilium upgrade` preserves it.

Overridable per-cluster via the existing vars mechanism.

## Notes

- Changing the pod CIDR on an already-running cluster is disruptive (pods get new IPs); this fix targets fresh provisioning.
- Verified the helm list-brace Jinja rendering produces `clusterPoolIPv4PodCIDRList='{10.42.0.0/16}'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)