### PR TITLE
feat(cilium): edge image-tar pre-load and configurable pull policy

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -196,6 +196,29 @@ cilium_enable_gateway_api: true
 cilium_gateway_api_crds_version: v1.4.1
 cilium_rollout_pods: true
 cilium_config: cilium.yaml
+# Pull policy applied to the Cilium components (agent/operator/envoy) via the
+# upgrade values file (templates/cilium-config.yaml.j2). Default "Always" keeps
+# the online behaviour; on edge/air-gapped devices set "Never" (strict, fails
+# loudly if an image is missing) or "IfNotPresent" together with the image
+# pre-load below. Note: only the `cilium upgrade -f` pass reads this file — the
+# initial `cilium install` uses cilium-cli's default (IfNotPresent), which already
+# uses a pre-loaded image without pulling.
+cilium_image_pull_policy: Always
+# Air-gapped / edge: pre-load the Cilium container images from a local tar into
+# containerd before install, so the agent/operator/envoy pods start without
+# reaching quay.io. Disabled by default (online pull). When enabled, the archive
+# at cilium_airgapped_archive_path is imported into the k8s.io namespace on every
+# node (the cilium agent DaemonSet runs cluster-wide). Pair with
+# cilium_image_pull_policy: Never to enforce a fully offline start.
+cilium_airgapped_images: false
+# Path to the Cilium images tar already present on the target node. Build it on a
+# connected host (e.g. `cilium images list` -> `docker save` / `ctr images export`)
+# and ship it to the device. An uncompressed .tar is safest; .zst/.gz require a
+# containerd `ctr` new enough to decompress on import.
+cilium_airgapped_archive_path: "/var/lib/rancher/cilium-images.tar"
+# ctr invocation used for the import. k3s ships `k3s ctr`; rke2 ships a ctr binary
+# under its bin dir. Both talk to the same socket (rke2_containerd_sock).
+cilium_ctr_cmd: "{{ 'k3s ctr' if install_k3s | bool else rke2_bin_dir ~ 'ctr' }}"
 # Pod IPAM pool. MUST NOT overlap the node/infrastructure network (e.g. lab 10.31.0.0/16)
 # or Cilium routes pod->infra traffic into the overlay and black-holes it. cilium-cli's
 # default is 10.0.0.0/8, which collides with RFC1918 lab nets — override it here.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -211,11 +211,19 @@ cilium_image_pull_policy: Always
 # node (the cilium agent DaemonSet runs cluster-wide). Pair with
 # cilium_image_pull_policy: Never to enforce a fully offline start.
 cilium_airgapped_images: false
-# Path to the Cilium images tar already present on the target node. Build it on a
-# connected host (e.g. `cilium images list` -> `docker save` / `ctr images export`)
-# and ship it to the device. An uncompressed .tar is safest; .zst/.gz require a
-# containerd `ctr` new enough to decompress on import.
-cilium_airgapped_archive_path: "/var/lib/rancher/cilium-images.tar"
+# HTTPS source for the Cilium images tar. Build the archive on a connected host
+# (e.g. `cilium images list` -> `docker save` / `ctr images export`), publish it to
+# an internal artifact store / release asset, and point this at it. Required when
+# cilium_airgapped_images is enabled. Mirrors rke2_airgapped_image_url.
+cilium_airgapped_image_url: ""
+# The tar is downloaded here on every node before import. An uncompressed .tar is
+# safest; .zst/.gz require a containerd `ctr` new enough to decompress on import.
+cilium_airgapped_install_dir: /var/lib/rancher/cilium-images
+cilium_airgapped_archive: cilium-images.tar
+cilium_airgapped_archive_path: "{{ cilium_airgapped_install_dir }}/{{ cilium_airgapped_archive }}"
+# Optional checksum (e.g. "sha256:<hash>" or "sha256:<url>") to verify the download
+# and fail loudly on truncation. Unset by default. Mirrors rke2_airgapped_checksum.
+# cilium_airgapped_checksum: "sha256:..."
 # ctr invocation used for the import. k3s ships `k3s ctr`; rke2 ships a ctr binary
 # under its bin dir. Both talk to the same socket (rke2_containerd_sock).
 cilium_ctr_cmd: "{{ 'k3s ctr' if install_k3s | bool else rke2_bin_dir ~ 'ctr' }}"

--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -5,18 +5,34 @@
     - ansible.builtin.include_role:
         name: download-install-binary
 
-# Air-gapped/edge: import the pre-staged Cilium images tar into containerd before
-# the install/upgrade so the agent (DaemonSet, hence every node), operator and
-# envoy pods start from the local store. Runs on all hosts, not just the master.
-# Pair with cilium_image_pull_policy: Never in cilium-config.yaml.j2 to forbid any
-# pull attempt.
+# Air-gapped/edge: fetch the Cilium images tar from an HTTPS source and import it
+# into containerd before the install/upgrade, so the agent (DaemonSet, hence every
+# node), operator and envoy pods start from the local store. Runs on all hosts, not
+# just the master. Pair with cilium_image_pull_policy: Never in cilium-config.yaml.j2
+# to forbid any pull attempt.
 - name: Pre-load Cilium images from tar
-  ansible.builtin.command: >
-    {{ cilium_ctr_cmd }} -a {{ rke2_containerd_sock }} -n k8s.io
-    images import {{ cilium_airgapped_archive_path }}
   become: true
-  register: cilium_image_import
-  changed_when: "'unpacking' in cilium_image_import.stdout"
+  block:
+    - name: Create Cilium air-gapped image dir
+      ansible.builtin.file:
+        path: "{{ cilium_airgapped_install_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Download Cilium images tar
+      ansible.builtin.get_url:
+        url: "{{ cilium_airgapped_image_url }}"
+        dest: "{{ cilium_airgapped_archive_path }}"
+        mode: "0644"
+        validate_certs: "{{ validate_certs }}"
+        checksum: "{{ cilium_airgapped_checksum | default(omit) }}"
+
+    - name: Import Cilium images into containerd
+      ansible.builtin.command: >
+        {{ cilium_ctr_cmd }} -a {{ rke2_containerd_sock }} -n k8s.io
+        images import {{ cilium_airgapped_archive_path }}
+      register: cilium_image_import
+      changed_when: "'unpacking' in cilium_image_import.stdout"
   when: cilium_airgapped_images | bool
 
 # Run cilium ops only against a stable apiserver. k3s has just started here, so

--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -30,7 +30,7 @@
     - name: Import Cilium images into containerd
       ansible.builtin.command: >
         {{ cilium_ctr_cmd }} -a {{ rke2_containerd_sock }} -n k8s.io
-        images import {{ cilium_airgapped_archive_path }}
+        images import --digests {{ cilium_airgapped_archive_path }}
       register: cilium_image_import
       changed_when: "'unpacking' in cilium_image_import.stdout"
   when: cilium_airgapped_images | bool

--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -5,6 +5,20 @@
     - ansible.builtin.include_role:
         name: download-install-binary
 
+# Air-gapped/edge: import the pre-staged Cilium images tar into containerd before
+# the install/upgrade so the agent (DaemonSet, hence every node), operator and
+# envoy pods start from the local store. Runs on all hosts, not just the master.
+# Pair with cilium_image_pull_policy: Never in cilium-config.yaml.j2 to forbid any
+# pull attempt.
+- name: Pre-load Cilium images from tar
+  ansible.builtin.command: >
+    {{ cilium_ctr_cmd }} -a {{ rke2_containerd_sock }} -n k8s.io
+    images import {{ cilium_airgapped_archive_path }}
+  become: true
+  register: cilium_image_import
+  changed_when: "'unpacking' in cilium_image_import.stdout"
+  when: cilium_airgapped_images | bool
+
 # Run cilium ops only against a stable apiserver. k3s has just started here, so
 # the API can still be flapping; installing/upgrading cilium against it can be
 # interrupted mid-operation and leave the Helm release stuck in pending-upgrade.

--- a/templates/cilium-config.yaml.j2
+++ b/templates/cilium-config.yaml.j2
@@ -3,6 +3,13 @@ k8sServiceHost: {{ cilium_api_server_ip }}
 k8sServicePort: {{ cilium_api_server_port }}
 kubeProxyReplacement: {{ cilium_kube_proxy_replacement }}
 
+# Pull policy for the Cilium agent image. On air-gapped/edge devices the images
+# are pre-loaded as a tar (cilium_airgapped_images) and this is set to "Never"
+# (or "IfNotPresent") so pods start from the local containerd store. Cilium has
+# no single global pull-policy key, so it is set per component below.
+image:
+  pullPolicy: {{ cilium_image_pull_policy }}
+
 l2announcements:
   enabled: true
 
@@ -22,6 +29,14 @@ ipam:
 operator:
   replicas: {{ cilium_operator_replicas }}
   rollOutPods: {{ cilium_rollout_pods }}
+  image:
+    pullPolicy: {{ cilium_image_pull_policy }}
+
+# Dedicated cilium-envoy DaemonSet (used by the ingress/gateway data path). The
+# key is harmless when Envoy runs embedded in the agent.
+envoy:
+  image:
+    pullPolicy: {{ cilium_image_pull_policy }}
 
 rollOutCiliumPods: {{ cilium_rollout_pods }}
 


### PR DESCRIPTION
## What

Lets Cilium run on air-gapped / edge devices by pre-loading its container images from a tar and pinning the image pull policy, instead of pulling from `quay.io`.

## Why

Cilium here is installed by **cilium-cli**, so it pulls upstream images directly from `quay.io`. On an edge/offline device those won't resolve. This adds an HTTPS-sourced image pre-load plus a configurable pull policy so pods start from the local containerd store.

## Changes

**`templates/cilium-config.yaml.j2`** — Cilium has no single global pull-policy key, so the policy is set per component, all driven by one variable:
- `image.pullPolicy` (agent), `operator.image.pullPolicy`, `envoy.image.pullPolicy`

**`defaults/main.yaml`** — new variables:
- `cilium_image_pull_policy` (default `Always` — keeps online behaviour; set `Never`/`IfNotPresent` on edge)
- `cilium_airgapped_images` (toggle, default `false`)
- `cilium_airgapped_image_url` — **HTTPS source** for the images tar (mirrors `rke2_airgapped_image_url`)
- `cilium_airgapped_install_dir` / `cilium_airgapped_archive` / `cilium_airgapped_archive_path`
- `cilium_airgapped_checksum` (optional, commented — mirrors `rke2_airgapped_checksum`)
- `cilium_ctr_cmd` — resolves to `k3s ctr` or rke2's `ctr` automatically (same containerd socket for both)

**`tasks/install-cilium.yaml`** — new gated block that, on **every node** (the agent is a DaemonSet):
1. creates the image dir,
2. downloads the tar from `cilium_airgapped_image_url` via `get_url` (with `validate_certs` + optional checksum),
3. imports it into containerd's `k8s.io` namespace before install/upgrade.

## Notes

- The values file only feeds `cilium upgrade -f`; the initial `cilium install` uses cilium-cli's default (`IfNotPresent`), which already uses a pre-loaded image without pulling, then the upgrade pins the policy. So the offline sequence works.
- The cilium-cli path runs when `rke2_cni: none` (RKE2) or on k3s — set `rke2_cni: none` for RKE2 edge nodes.
- For the image download I used `ansible.builtin.get_url` (the file-download module the repo already uses for the `rke2_airgapped`/`k3s_airgapped` tarballs, with native checksum verification) rather than `uri`. Happy to switch to `uri` if preferred.

## Validation

- Template renders to valid YAML (`pullPolicy: Never` across agent/operator/envoy).
- All edited YAML parses.

Default behaviour is unchanged unless `cilium_airgapped_images` is enabled and the pull policy is overridden.

https://claude.ai/code/session_01V5sfqjyV8Y3X7MDC9EvQZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5sfqjyV8Y3X7MDC9EvQZ8)_