### PR TITLE
fix(cilium): correct changed_when for ctr image import + add airgap+mirror test

### DIFF
--- a/tasks/install-cilium.yaml
+++ b/tasks/install-cilium.yaml
@@ -32,7 +32,14 @@
         {{ cilium_ctr_cmd }} -a {{ rke2_containerd_sock }} -n k8s.io
         images import --digests {{ cilium_airgapped_archive_path }}
       register: cilium_image_import
-      changed_when: "'unpacking' in cilium_image_import.stdout"
+      # ctr's import wording varies by tar format: `ctr images export` archives
+      # (what hack/export-cilium-images.sh produces) report "saved"; docker-save
+      # archives report "unpacking"/"unpacked". Match all so a real import isn't
+      # misreported as unchanged.
+      changed_when: >-
+        cilium_image_import.rc == 0 and
+        ('saved' in cilium_image_import.stdout
+         or 'unpack' in cilium_image_import.stdout)
   when: cilium_airgapped_images | bool
 
 # Run cilium ops only against a stable apiserver. k3s has just started here, so

--- a/tests/k3s-cilium-airgap-mirror.yaml
+++ b/tests/k3s-cilium-airgap-mirror.yaml
@@ -1,0 +1,56 @@
+---
+# ----------------------------------------------------------------------------
+# Test: k3s (v1.36.1+k3s1) single-node, with:
+#   * air-gapped k3s IMAGES from the public mirror (images-only; binary upstream)
+#   * docker.io pull-through MIRROR -> harbor (with upstream fallback)
+#   * Cilium AIR-GAPPED images: pre-loaded from a tar into containerd, with
+#     pullPolicy: Never so the agent/operator/envoy start from the local store
+#     instead of pulling quay.io.
+#
+# Run:
+#   export ANSIBLE_ROLES_PATH=$(dirname "$PWD"):$HOME/.ansible/roles
+#   ansible-playbook -i tests/inventory-k3s-airgap.yaml tests/k3s-cilium-airgap-mirror.yaml -vv
+# ----------------------------------------------------------------------------
+- name: Deploy k3s (air-gapped images + harbor mirror + Cilium image tar)
+  hosts: all
+  gather_facts: true
+  become: true
+
+  vars:
+    install_k3s: true
+    k3s_state: present
+    k3s_k8s_version: 1.36.1
+    k3s_release_kind: k3s1
+    cluster_setup: singlenode
+    install_cilium: true
+
+    # fetch the kubeconfig back to the control host for verification
+    fetched_kubeconfig_path: /tmp/k3s-cilium-airgap-test/kubeconfig
+
+    # --- air-gapped k3s IMAGES from the public mirror (images only) ---------
+    k3s_airgapped_installation: true
+    k3s_airgapped_skip_download: false
+    k3s_airgapped_image_url: "https://artifacts.platform.sthings-vsphere.labul.sva.de/airgap/k3s/v1.36.1-k3s1/k3s-airgap-images-amd64.tar.zst"
+    k3s_airgapped_checksum: "sha256:72cf836bfcf8f9af2de88102b69129d297b77a60243895a7ac4bc47d77a65079"
+
+    # --- docker.io pull-through mirror -> harbor (fallback to upstream) ------
+    k3s_registry_mirrors:
+      - name: "docker.io"
+        endpoints:
+          - "https://docker.harbor.platform.sthings-vsphere.labul.sva.de"
+          - "https://registry-1.docker.io"
+
+    # --- Cilium air-gapped images (the feature under test) ------------------
+    # Pre-load Cilium images from the tar into containerd, then pin pullPolicy
+    # so pods start offline from the local store. Checksum intentionally skipped.
+    cilium_airgapped_images: true
+    cilium_airgapped_image_url: "https://artifacts.platform.sthings-vsphere.labul.sva.de/airgap/cilium-images.tar"
+    cilium_image_pull_policy: Never
+
+    # Pod CIDR must not overlap the infra net (10.31.0.0/16). Defaults are fine
+    # (10.42.0.0/16, /24) but pinned here to make the test explicit.
+    cilium_cluster_pool_ipv4_cidr: 10.42.0.0/16
+    cilium_cluster_pool_ipv4_mask_size: 24
+
+  roles:
+    - role: deploy-configure-rke


### PR DESCRIPTION
## What

Fixes the air-gapped Cilium image-import task misreporting `changed: false`, and adds the end-to-end test that surfaced it.

## The bug

`tasks/install-cilium.yaml` had `changed_when: "'unpacking' in stdout"`. But `ctr images import` wording depends on the tar format:
- archives from `ctr images export` (what `hack/export-cilium-images.sh` produces) report **`saved`**
- `docker save` archives report **`unpacking`**

So a real import of our own export-built tar always reported `ok`/unchanged. Now matches `saved` **or** `unpack`, gated on `rc == 0`.

## Test added

`tests/k3s-cilium-airgap-mirror.yaml` — clean k3s node + Harbor pull-through mirror + Cilium image tar.

## Verified on a clean node (10.31.101.107)

- Import: rc=0, all 3 images `saved` into containerd (digest refs).
- Cilium agent/operator/envoy **Running 1/1** with `imagePullPolicy: Never` — started from the local store (pull forbidden).
- Harbor mirror in `registries.yaml`; rendered `cilium.yaml` has `ipam` + per-component `pullPolicy`; pod CIDR `10.42.0.0/24` (no infra overlap); 6/6 pods Running.

Follow-up to #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)